### PR TITLE
Remove lang="html" from template for Vite compatibility

### DIFF
--- a/src/MultipartForm.vue
+++ b/src/MultipartForm.vue
@@ -1,4 +1,4 @@
-<template lang="html">
+<template>
   <md-layout column md-flex="100">
     <md-layout row md-flex="100" v-for="key in Object.keys(properties)" :key="`property_${key}`">
       <!-- File upload -->

--- a/src/ParametersTable.vue
+++ b/src/ParametersTable.vue
@@ -1,4 +1,4 @@
-<template lang="html">
+<template>
   <md-table v-if="(selectedEntry.parameters && selectedEntry.parameters.length) || selectedEntry.requestBody">
     <md-table-header>
       <md-table-row>

--- a/src/RequestForm.vue
+++ b/src/RequestForm.vue
@@ -1,4 +1,4 @@
-<template lang="html">
+<template>
   <form novalidate @submit.stop.prevent="submit" v-if="selectedEntry" id="request-form">
     <md-subheader v-if="selectedEntry.security && selectedEntry.security.filter(s => s.scheme.in !== 'cookie').length">
       Security

--- a/src/ResponseDisplay.vue
+++ b/src/ResponseDisplay.vue
@@ -1,4 +1,4 @@
-<template lang="html">
+<template>
   <md-layout md-column class="response-display">
     <span>{{entry.method.toUpperCase()}} {{response.url}}&nbsp;&nbsp;&nbsp;&nbsp;<md-chip :class="response.ok ? 'md-primary':'md-warn'">{{response.status}} {{response.statusText}}</md-chip></span>
     <br>

--- a/src/ResponsesTable.vue
+++ b/src/ResponsesTable.vue
@@ -1,4 +1,4 @@
-<template lang="html">
+<template>
   <md-table>
     <md-table-header>
       <md-table-row>

--- a/src/SecurityTable.vue
+++ b/src/SecurityTable.vue
@@ -1,4 +1,4 @@
-<template lang="html">
+<template>
   <md-table>
     <md-table-header>
       <md-table-row>

--- a/src/Snippet.vue
+++ b/src/Snippet.vue
@@ -1,4 +1,4 @@
-<template lang="html">
+<template>
   <div>
     <pre>
       <code>


### PR DESCRIPTION
Removing lang="html" from the template fixes the following: "Error: Component <path/name.vue> uses lang html for template, however it is not installed."
As vue assumes that the template is going to be using html removing lang="html" shouldn't break anything